### PR TITLE
バグ修正

### DIFF
--- a/EditFile.cpp
+++ b/EditFile.cpp
@@ -273,6 +273,10 @@ void EditFile::OnOK()
 		{
 			Attr |= 0x1;
 		}
+		else
+		{
+			Attr &= 0xFE;
+		}
 		ZeroMemory( temp, sizeof( temp ) );
 		size = m_Reserve.GetLine( 0, temp, 260 );
 		temp[size] = '\0';
@@ -342,7 +346,8 @@ void EditFile::OnOK()
 				break;
 			}
 		}
-		dir.attr = Attr;
+		dir.attr &= 0xFE;
+		dir.attr |= (Attr & 1);
 		dir.reserve = Reserve;
 		if(dir.mode == 4)
 		{
@@ -529,7 +534,8 @@ void EditFile::OnOK()
 				break;
 			}
 		}
-		dir.attr = Attr;
+		dir.attr &= 0xFE;
+		dir.attr |= (Attr & 1);
 		if(dir.mode == 4)
 		{
 			dir.size = FileSize / 32;

--- a/MzDisk/Mz80Disk.cpp
+++ b/MzDisk/Mz80Disk.cpp
@@ -87,7 +87,7 @@ void Mz80Disk::Format(int type, int volumeNumber)
 	{
 		return;
 	}
-	this->diskType = TYPE_2S;
+	this->diskType = D88Image::DISK_2S_35_128_16;
 	// 物理フォーマット
 	this->image.Format(type, 0x00);
 	// 論理フォーマット
@@ -351,11 +351,15 @@ int Mz80Disk::PutFile(std::string path, void* dirInfo, unsigned int mode, unsign
 		{
 			if(this->directory[i].mode != 0)
 			{
-				// ファイルネーム
-				if(strncmp(this->directory[i].filename, filename, strlen(filename)) == 0)
+				// ファイル名の長さが同じ?
+				if(strlen(this->directory[i].filename) == strlen(filename))
 				{
-					// 同じファイル名が存在する
-					return 5;
+					// ファイルネームが同じ?
+					if(strncmp(this->directory[i].filename, filename, strlen(filename)) == 0)
+					{
+						// 同じファイル名が存在する
+						return 5;
+					}
 				}
 			}
 		}

--- a/MzDisk/Mz80SP6110Disk.cpp
+++ b/MzDisk/Mz80SP6110Disk.cpp
@@ -86,7 +86,7 @@ void Mz80SP6110Disk::Format(int type, int volumeNumber)
 {
 	if(type != DISKTYPE_MZ80_SP6110_2S)
 	{
-		this->diskType = TYPE_2S;
+		this->diskType = D88Image::DISK_2S_35_128_16;
 	}
 	this->diskType = TYPE_2S;
 	// 物理フォーマット
@@ -365,11 +365,15 @@ int Mz80SP6110Disk::PutFile(std::string path, void* dirInfo, unsigned int mode, 
 		{
 			if(this->directory[i].mode != 0)
 			{
-				// ファイルネーム
-				if(strncmp(this->directory[i].filename, filename, strlen(filename)) == 0)
+				// ファイル名の長さが同じ?
+				if(strlen(this->directory[i].filename) == strlen(filename))
 				{
-					// 同じファイル名が存在する
-					return 5;
+					// ファイルネームが同じ?
+					if(strncmp(this->directory[i].filename, filename, strlen(filename)) == 0)
+					{
+						// 同じファイル名が存在する
+						return 5;
+					}
 				}
 			}
 		}

--- a/MzDisk/MzDisk.cpp
+++ b/MzDisk/MzDisk.cpp
@@ -151,27 +151,27 @@ void MzDisk::Format(int type, int volumeNumber)
 {
 	if(type == DISKTYPE_MZ2500_2DD)
 	{
-		this->mediaType = TYPE_2DD;
+		this->mediaType = D88Image::DISK_2DD_80_256_16;
 	}
 	else if(type == DISKTYPE_MZ2500_2DD40)
 	{
-		this->mediaType = TYPE_2DD;
+		this->mediaType = D88Image::DISK_2DD_40_256_16;
 	}
 	else if(type == DISKTYPE_MZ2500_2DD35)
 	{
-		this->mediaType = TYPE_2DD;
+		this->mediaType = D88Image::DISK_2DD_35_256_16;
 	}
 	else if(type == DISKTYPE_MZ80B_2D35)
 	{
-		this->mediaType = TYPE_2D;
+		this->mediaType = D88Image::DISK_2D_35_256_16;
 	}
 	else if(type == DISKTYPE_MZ2000_2D40)
 	{
-		this->mediaType = TYPE_2D;
+		this->mediaType = D88Image::DISK_2D_40_256_16;
 	}
 	else if(type == DISKTYPE_MZ80A_2D35)
 	{
-		this->mediaType = TYPE_2D;
+		this->mediaType = D88Image::DISK_2D_35_256_16;
 	}
 	else
 	{
@@ -588,11 +588,15 @@ int MzDisk::PutFile(std::string path, void* dirInfo, unsigned int mode, unsigned
 		{
 			if(this->directory[i].mode != 0)
 			{
-				// ファイルネーム
-				if(strncmp(this->directory[i].filename, filename, strlen(filename)) == 0)
+				// ファイル名の長さが同じ?
+				if(strlen(this->directory[i].filename) == strlen(filename))
 				{
-					// 同じファイル名が存在する
-					return 5;
+					// ファイルネームが同じ?
+					if(strncmp(this->directory[i].filename, filename, strlen(filename)) == 0)
+					{
+						// 同じファイル名が存在する
+						return 5;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
書き込みファイル名を含むファイルがディスクにある場合書き込めなかったのを修正。
ディスクの新規作成がフリーズ及び失敗するのを修正。
プロテクトがなしに設定できなかったのを修正。